### PR TITLE
Onshop feature gap

### DIFF
--- a/app/LogFile.php
+++ b/app/LogFile.php
@@ -158,7 +158,7 @@ class LogFile
      * @param string $folder
      * @return Collection
      */
-    protected static function filesInFolder(string $folder): Collection
+    public static function filesInFolder(string $folder): Collection
     {
         return collect(LogFile::disk()->files($folder))->map(function ($full_name) {
             return basename($full_name);

--- a/app/LogFile.php
+++ b/app/LogFile.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Write a log file a Storage facade disk, 
+ * Write a log file a Storage facade disk,
  * using a standardized file name (ISO-8601 with microseconds)
  * lots of helpful formatters, especially around Guzzle Requests, Responses, and Exceptions
  * and using a log structure provided by the caller.
- * 
- * If you're thoughtful about building metadata into the log folder structure, it's easy to build a GUI to list and retrieve those logs 
+ *
+ * If you're thoughtful about building metadata into the log folder structure, it's easy to build a GUI to list and retrieve those logs
  */
 
 namespace Carsdotcom\ApiRequest;
@@ -14,6 +14,7 @@ use Carbon\Carbon;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -109,6 +110,8 @@ class LogFile
                 $string .= "\n\n" . self::stringify_body($body->getResponse());
             }
             return $string;
+        } elseif ($body instanceof TransferStats) {
+            return sprintf('Transfer time: %ss', $body->getTransferTime());
         } elseif (is_object($body) && method_exists($body, ' __toString')) {
             return $body->toString();
         }

--- a/app/Testing/MocksGuzzleInstance.php
+++ b/app/Testing/MocksGuzzleInstance.php
@@ -53,14 +53,18 @@ trait MocksGuzzleInstance
      */
     protected function mockZeroGuzzleRequests(): void
     {
-        $this->mockGuzzleWithTapper();
         $exceptionResponse = new RequestException('Guzzle should not have been called.', new Request('GET', 'test'));
-        $this->tapper->addMatch('POST', '/.*?/', $exceptionResponse);
-        $this->tapper->addMatch('GET', '/.*?/', $exceptionResponse);
-        $this->tapper->addMatch('PUT', '/.*?/', $exceptionResponse);
-        $this->tapper->addMatch('PATCH', '/.*?/', $exceptionResponse);
-        $this->tapper->addMatch('DELETE', '/.*?/', $exceptionResponse);
-        $this->tapper->addMatch('OPTIONS', '/.*?/', $exceptionResponse);
+        $this->mockGuzzleWithTapper()
+            ->addMatch('POST', '/.*?/', $exceptionResponse)
+            ->addMatch('GET', '/.*?/', $exceptionResponse)
+            ->addMatch('PUT', '/.*?/', $exceptionResponse)
+            ->addMatch('PATCH', '/.*?/', $exceptionResponse)
+            ->addMatch('DELETE', '/.*?/', $exceptionResponse)
+            ->addMatch('OPTIONS', '/.*?/', $exceptionResponse);
+        // The tapper defined above has been dependency injected, but the reference in $this
+        // is broken, meaning a later call to $this->mockGuzzleWithTapper() will overwrite
+        // the one in dependency injection
+        $this->tapper = null;
     }
 
     /**


### PR DESCRIPTION
Adding some features to make this work correctly with Online Shopper.

1. Onshop runs `mockZeroGuzzleRequests` during `setUp` for all tests, then overrides it on _some_ tests.
2. Onshop wants transfer time logged on all request bodies.
3. Onshop had extra unit tests around `setBodyIfNotEmpty` -- no code changes just improved coverage