### PR TITLE
feat: On cache hit, the request class has access to the log file when the cache was written

### DIFF
--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -323,12 +323,15 @@ abstract class AbstractRequest
         Cache::tags($this->cacheTags)->put(
             $this->cacheKey(),
             [
-                // matches the argument order for Response constructor
-                $this->response->getStatusCode(),
-                $this->response->getHeaders(),
-                (string) $this->response->getBody(),
-                $this->response->getProtocolVersion(),
-                $this->response->getReasonPhrase(),
+                'logs' => $this->sentLogs,
+                'response' => [
+                    // matches the argument order for Response constructor
+                    $this->response->getStatusCode(),
+                    $this->response->getHeaders(),
+                    (string) $this->response->getBody(),
+                    $this->response->getProtocolVersion(),
+                    $this->response->getReasonPhrase(),
+                ]
             ],
             $this->cacheExpiresTime(),
         );
@@ -341,7 +344,11 @@ abstract class AbstractRequest
         }
 
         $fromCache = Cache::tags($this->cacheTags)->get($this->cacheKey());
-        return $fromCache ? new Response(...$fromCache) : null;
+        if ($fromCache) {
+            $this->sentLogs = $fromCache['logs'];
+            return new Response(...$fromCache['response']);
+        }
+        return null;
     }
 
     /**
@@ -388,9 +395,6 @@ abstract class AbstractRequest
      */
     public function getLastLogContents(): string
     {
-        if (!$this->sentLogs) {
-            throw new DomainException('No log files have been saved by this instance.');
-        }
         return LogFile::disk()->get($this->getLastLogFile());
     }
 
@@ -450,7 +454,7 @@ abstract class AbstractRequest
                 self::class,
                 $this->getURL(),
                 $this->encodeBody(),
-                config('api-request.cache_key_seed', 'v2022.4.12.0'),
+                config('api-request.cache_key_seed', 'v2024.8.6'),
             ]),
         );
     }
@@ -460,11 +464,11 @@ abstract class AbstractRequest
         return Cache::tags($this->cacheTags)->has($this->cacheKey());
     }
 
-    /**
-     * @return string
-     */
     public function getLastLogFile(): string
     {
+        if (!$this->sentLogs) {
+            throw new DomainException('No log files have been saved by this instance.');
+        }
         return Str::finish($this->getLogFolder(), '/') . Arr::last($this->sentLogs);
     }
 
@@ -476,5 +480,10 @@ abstract class AbstractRequest
     public function setTimeout(CarbonInterval $interval): void
     {
         $this->guzzleOptions[RequestOptions::TIMEOUT] = $interval->totalSeconds;
+    }
+
+    public function isFromCache(): bool
+    {
+        return $this->responseIsFromCache;
     }
 }

--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -352,6 +352,33 @@ abstract class AbstractRequest
     }
 
     /**
+     * Return cache key string based on this class, URL, and request body
+     * @return string
+     */
+    public function cacheKey(): string
+    {
+        return hash(
+            'sha256',
+            json_encode([
+                self::class,
+                $this->getURL(),
+                $this->encodeBody(),
+                config('api-request.cache_key_seed', 'v2024.8.6'),
+            ]),
+        );
+    }
+
+    public function canBeFulfilledByCache(): bool
+    {
+        return Cache::tags($this->cacheTags)->has($this->cacheKey());
+    }
+
+    public function isFromCache(): bool
+    {
+        return $this->responseIsFromCache;
+    }
+
+    /**
      * For caching the response, how long should the cache be valid?
      * By default, this is one day. To customize, override this method.
      * i.e. If you need logic (e.g., read from an Expires: header in the response) override this method.
@@ -399,6 +426,19 @@ abstract class AbstractRequest
     }
 
     /**
+     * Get the filename for the last run of this instance of this request.
+     * If the last sync or async was a cache hit, this will return the original log of the request that was cached
+     * @throws DomainException if this instance has never logged (could mean never run, or $shouldLog is false)
+     */
+    public function getLastLogFile(): string
+    {
+        if (!$this->sentLogs) {
+            throw new DomainException('No log files have been saved by this instance.');
+        }
+        return Str::finish($this->getLogFolder(), '/') . Arr::last($this->sentLogs);
+    }
+
+    /**
      * Can be overridden by children or trait to parse the body in a known format (e.g. JSON or XML)
      * @param string $responseString
      * @return mixed (as dictated by traits like ParseResponseJson)
@@ -443,36 +483,6 @@ abstract class AbstractRequest
     }
 
     /**
-     * Return cache key string based on this class, URL, and request body
-     * @return string
-     */
-    public function cacheKey(): string
-    {
-        return hash(
-            'sha256',
-            json_encode([
-                self::class,
-                $this->getURL(),
-                $this->encodeBody(),
-                config('api-request.cache_key_seed', 'v2024.8.6'),
-            ]),
-        );
-    }
-
-    public function canBeFulfilledByCache(): bool
-    {
-        return Cache::tags($this->cacheTags)->has($this->cacheKey());
-    }
-
-    public function getLastLogFile(): string
-    {
-        if (!$this->sentLogs) {
-            throw new DomainException('No log files have been saved by this instance.');
-        }
-        return Str::finish($this->getLogFolder(), '/') . Arr::last($this->sentLogs);
-    }
-
-    /**
      * Change the timeout of this request. This is the preferred way to override the default,
      * even in the constructor of a custom class I think this is much more expressive than a numeric constant
      * @example $this->setTimeout(CarbonInterval::minutes(5));
@@ -482,8 +492,4 @@ abstract class AbstractRequest
         $this->guzzleOptions[RequestOptions::TIMEOUT] = $interval->totalSeconds;
     }
 
-    public function isFromCache(): bool
-    {
-        return $this->responseIsFromCache;
-    }
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -39,7 +39,7 @@ class BaseTestCase extends TestCase
         array $headers = [],
     ) {
         $tags = getProperty($request, 'cacheTags');
-        Cache::tags($tags)->put($request->cacheKey(), [$status, $headers, $body]);
+        Cache::tags($tags)->put($request->cacheKey(), ['logs' => [], 'response' => [$status, $headers, $body]]);
     }
 
     /**

--- a/tests/Feature/AbstractRequestTest.php
+++ b/tests/Feature/AbstractRequestTest.php
@@ -31,6 +31,12 @@ class AbstractRequestTest extends BaseTestCase
 {
     use MocksGuzzleInstance;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('api-logs');
+    }
+
     protected function mockRequestWithLog()
     {
         return new class extends ConcreteRequest {
@@ -38,15 +44,9 @@ class AbstractRequestTest extends BaseTestCase
 
             protected bool $shouldLog = true;
 
-            public $logged;
-            public function log($outcome): void
+            public function getLogFolder(): string
             {
-                $this->logged = $outcome;
-            }
-
-            public function isFromCache(): bool
-            {
-                return $this->responseIsFromCache;
+                return 'one/two';
             }
         };
     }
@@ -54,14 +54,13 @@ class AbstractRequestTest extends BaseTestCase
     public function testCacheMissUsesGuzzle(): void
     {
         $this->mockGuzzleWithTapper();
-        $expectedResponse = new Response(200, [], '{"awesome":"sauce"}');
-        $this->tapper->addMatch('POST', '/.*?/', $expectedResponse);
+        $this->tapper->addMatchBody('POST', '/.*?/', '{"awesome":"sauce"}');
 
         $requestClass = $this->mockRequestWithLog();
 
         $result = $requestClass->sync();
 
-        self::assertSame($expectedResponse, $requestClass->logged);
+        self::assertStringContainsString('"sauce"', $requestClass->getLastLogContents());
         $this->expectTotalRequestCount(1);
         $this->assertTapperRequestLike('POST', '/.*?/', 1);
 
@@ -101,6 +100,38 @@ class AbstractRequestTest extends BaseTestCase
 
         // Result matches cache
         self::assertTrue($secondRequest->canBeFulfilledByCache());
+    }
+
+    public function testCacheHitHasAccessToOriginalLog(): void
+    {
+        Storage::fake('api-logs');
+        $tapper = $this->mockGuzzleWithTapper();
+        $tapper->addMatchBody('POST', '/awesome/', '{"awesome":"sauce"}');
+
+        $firstLogTime = '2018-01-01T00:00:00.000000+00:00';
+        Carbon::setTestNow($firstLogTime);
+        $firstRequest = $this->mockRequestWithLog();
+        $firstRequest->sync();
+        self::assertTrue($firstRequest->canBeFulfilledByCache());
+        self::assertSame($firstRequest->getLastLogFile(), "one/two/{$firstLogTime}");
+        self::assertSame(1, $tapper->getCountLike('POST', '/awesome/'));
+
+        // Regenerate the request
+        $secondLogTime = '2018-01-01T00:02:02.000000+00:00';
+        Carbon::setTestNow($secondLogTime);
+        $secondRequest = $this->mockRequestWithLog();
+        self::assertTrue($secondRequest->canBeFulfilledByCache());
+        // Both requests have same key
+        self::assertSame($firstRequest->cacheKey(), $secondRequest->cacheKey());
+
+        $secondRequest->sync();
+        self::assertSame(1, $tapper->getCountLike('POST', '/awesome/'));
+        // Result was in cache
+        self::assertTrue($secondRequest->isFromCache());
+        // Second request can retrieve log from original time
+        self::assertSame($secondRequest->getLastLogFile(), "one/two/{$firstLogTime}");
+        // Second request did not log to disk, only the first request
+        self::assertSame(["one/two/{$firstLogTime}"], Storage::disk('api-logs')->files('one/two'));
     }
 
     public function testDontCacheErrorStatus(): void
@@ -320,6 +351,7 @@ class AbstractRequestTest extends BaseTestCase
         $tapper->addMatchBody('POST', '/awesome/', 'true');
 
         $this->expectException(ToDoException::class);
+        $this->expectExceptionMessageMatches('/To enable request logging, .+ will have to implement the method getLogFolder/');
         $request->sync();
     }
 
@@ -366,6 +398,12 @@ class AbstractRequestTest extends BaseTestCase
         } catch (\DomainException $exception) {
             self::assertSame('No log files have been saved by this instance.', $exception->getMessage());
         }
+        try {
+            $request->getLastLogFile();
+            self::fail('Should have thrown');
+        } catch (\DomainException $exception) {
+            self::assertSame('No log files have been saved by this instance.', $exception->getMessage());
+        }
 
         $tapper = $this->mockGuzzleWithTapper();
         $tapper->addMatchBody('POST', '/awesome/', 'true');
@@ -374,6 +412,7 @@ class AbstractRequestTest extends BaseTestCase
         Carbon::setTestNow($firstLogTime);
         $request->sync();
         Storage::disk('api-logs')->assertExists("one/two/{$firstLogTime}");
+        self::assertSame($request->getLastLogFile(), "one/two/{$firstLogTime}");
         self::assertSame($request->getLastLogContents(), Storage::disk('api-logs')->get("one/two/{$firstLogTime}"));
 
         // Make a second log, see that it's now returned
@@ -383,6 +422,7 @@ class AbstractRequestTest extends BaseTestCase
         Carbon::setTestNow($secondLogTime);
         $request->sync();
         Storage::disk('api-logs')->assertExists("one/two/{$secondLogTime}");
+        self::assertSame($request->getLastLogFile(), "one/two/{$secondLogTime}");
         self::assertSame($request->getLastLogContents(), Storage::disk('api-logs')->get("one/two/{$secondLogTime}"));
     }
 
@@ -553,7 +593,7 @@ class AbstractRequestTest extends BaseTestCase
         Cache::shouldReceive('get')
             ->once()
             ->with($request->cacheKey())
-            ->andReturn([200, [], '42']);
+            ->andReturn(['logs' => [], 'response' => [200, [], '42']]);
         // It is NOT written back to cache
         Cache::shouldReceive('put')->never();
 


### PR DESCRIPTION
This helps resolve the Cars Commerce issue https://carscommerce.atlassian.net/browse/MR-3416