### PR TITLE
feat: A request can choose to ignore dependency injection for the Guzzle Client

### DIFF
--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -19,6 +19,7 @@ use Carbon\CarbonInterval;
 use Carsdotcom\ApiRequest\Exceptions\ToDoException;
 use Carbon\Carbon;
 use DomainException;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -273,7 +274,7 @@ abstract class AbstractRequest
                     $this->response = $cached;
                     $promise = new FulfilledPromise($cached);
                 } else {
-                    $promise = App::make('guzzle')
+                    $promise = $this->getGuzzleClient()
                         ->sendAsync($this->toGuzzle(), $this->guzzleOptions)
                         ->then(function (Response $response) {
                             $this->responseIsFromCache = false;
@@ -300,6 +301,16 @@ abstract class AbstractRequest
             })
             ->otherwise($this->otherwise(...));
     }
+
+    /**
+     * This method can be overridden if a request class shouldn't share a Guzzle Client with the rest of the app
+     * This can be useful if one request needs to be mocked with Tapper, even when other requests send real traffic.
+     */
+    protected function getGuzzleClient(): Client
+    {
+        return App::make('guzzle');
+    }
+
 
     public function purgeCache(): self
     {

--- a/app/Testing/GuzzleTapper.php
+++ b/app/Testing/GuzzleTapper.php
@@ -10,6 +10,9 @@
 namespace Carsdotcom\ApiRequest\Testing;
 
 use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Collection;
 use OutOfBoundsException;
@@ -139,6 +142,18 @@ class GuzzleTapper
     public function getResponses(): array
     {
         return array_fill(0, 100, [$this, 'response']);
+    }
+
+    /**
+     * Returns a new Guzzle Http Client using Tapper to fulfill all requests.
+     * This client is suitable for use in AbstractRequest::getGuzzleClient
+     * or a dependency injection system like Laravel's App::instance
+     */
+    public function makeMockedGuzzleClient(): Client
+    {
+        $mockHandler = new MockHandler($this->getResponses());
+        $handlerStack = HandlerStack::create($mockHandler);
+        return new Client(['handler' => $handlerStack]);
     }
 
     /**

--- a/app/Testing/MocksGuzzleInstance.php
+++ b/app/Testing/MocksGuzzleInstance.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Trait to include to mock the guzzle instance into the app
+ * Add this trait to a unit test (or even your base TestCase)
+ * to allow you to replace your dependency injected Guzzle Client with the GuzzleTapper library.
+ *
+ * This will allow you to mock the methods and URLs that will be called
+ * (including even behavior that responds to the URL or request body)
+ * instead of Laravel Http facade's typical order-based matching
  */
 declare(strict_types=1);
 
@@ -15,14 +20,13 @@ use Psr\Http\Message\RequestInterface;
 
 trait MocksGuzzleInstance
 {
-    /** @var GuzzleTapper|null */
-    protected $tapper;
+    protected GuzzleTapper|null $tapper = null;
 
     /**
      * Replace Laravel's dependency-injected Guzzle
      * with a Client that responds with GuzzleTappers matching process
      * Note, you can keep adding new responses to GuzzleTapper any time before the matched request is made
-     * @return GuzzleTapper
+     * @see http://docs.guzzlephp.org/en/stable/testing.html
      */
     protected function mockGuzzleWithTapper(): GuzzleTapper
     {
@@ -30,8 +34,7 @@ trait MocksGuzzleInstance
             $this->tapper = new GuzzleTapper();
         }
 
-        $handler = new MockHandler($this->tapper->getResponses());
-        $this->mockGuzzleAppInstanceWithHandler($handler);
+        $this->app->instance('guzzle', $this->tapper->makeMockedGuzzleClient());
 
         return $this->tapper;
     }
@@ -57,10 +60,6 @@ trait MocksGuzzleInstance
 
     /**
      * Request has the header, and the value is or contains the required value
-     * @param Request $request
-     * @param string $headerName
-     * @param string $headerValue
-     * @param string|null $message
      */
     protected function assertSameRequestHeader(
         Request $request,
@@ -77,9 +76,6 @@ trait MocksGuzzleInstance
         }
     }
 
-    /**
-     * @param int $expectedRequestCount
-     */
     protected function expectTotalRequestCount(int $expectedRequestCount): void
     {
         if (!$this->tapper) {
@@ -144,18 +140,4 @@ trait MocksGuzzleInstance
         }
     }
 
-    /**
-     * Create a real guzzle client that can use a MockHandler class to mock all
-     * requests.
-     * @see http://docs.guzzlephp.org/en/stable/testing.html
-     * @param MockHandler $mock
-     * @return Client
-     */
-    private function mockGuzzleAppInstanceWithHandler(MockHandler $mock): Client
-    {
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
-        $this->app->instance('guzzle', $client);
-        return $client;
-    }
 }

--- a/tests/Feature/AbstractRequestTest.php
+++ b/tests/Feature/AbstractRequestTest.php
@@ -5,13 +5,17 @@ namespace Tests\Feature;
 use Carbon\CarbonInterval;
 use Carsdotcom\ApiRequest\Exceptions\UpstreamException;
 use Carsdotcom\ApiRequest\Exceptions\ToDoException;
+use Carsdotcom\ApiRequest\Testing\GuzzleTapper;
 use Carsdotcom\ApiRequest\Traits\EncodeRequestJSON;
 use Carsdotcom\ApiRequest\Traits\ParseResponseJSON;
 use Carsdotcom\ApiRequest\Traits\ParseResponseJSONOrThrow;
 use Carbon\Carbon;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
@@ -128,8 +132,9 @@ class AbstractRequestTest extends BaseTestCase
         self::assertSame(1, $tapper->getCountLike('POST', '/awesome/'));
         // Result was in cache
         self::assertTrue($secondRequest->isFromCache());
-        // Second request can retrieve log from original time
+        // Second request can retrieve log from original time with original contents
         self::assertSame($secondRequest->getLastLogFile(), "one/two/{$firstLogTime}");
+        self::assertStringContainsString('"sauce"', $secondRequest->getLastLogContents());
         // Second request did not log to disk, only the first request
         self::assertSame(["one/two/{$firstLogTime}"], Storage::disk('api-logs')->files('one/two'));
     }
@@ -692,6 +697,41 @@ class AbstractRequestTest extends BaseTestCase
                 ,
                 $request->getLastLogContents(),
             );
+        }
+    }
+
+    /**
+     * In this example, $requestWithCustomTapper always uses a mocked response, even when the Guzzle Client in the
+     * App's dependency store does not.  This can be useful when you're building a Request class around documentation,
+     * and the endpoint you *will* call is not yet ready to be called.
+     * The getGuzzleClient method knows that it's returning mock data, every other part of your application acts
+     * as if the request is completely legitimate -- even logging and caching!
+     */
+    public function testRequestCanReturnStaticResponseWithoutAffectingDependencyStore(): void
+    {
+        $requestWithCustomTapper = new class extends ConcreteRequest {
+            protected bool $shouldWriteCache = false; // the requests are identical but we want the second to still try to call the network (and fail)
+            protected function getGuzzleClient(): Client
+            {
+                $tapper = new GuzzleTapper();
+                $tapper->addMatchBody('POST', '/awesome/', 'Static data as documented', 200);
+                $mockHandler = new MockHandler($tapper->getResponses());
+                $handlerStack = HandlerStack::create($mockHandler);
+                return new Client(['handler' => $handlerStack]);
+            }
+        };
+        $this->mockGuzzleWithTapper()->addMatchBody('POST', '/awesome/', 'This method is not implemented', 500);
+
+        $resultFromRequestTapper = $requestWithCustomTapper->sync();
+        self::assertSame('Static data as documented', $resultFromRequestTapper);
+
+        $requestWithSystemGuzzle = new ConcreteRequest();
+        try {
+            $requestWithSystemGuzzle->sync();
+            self::fail("Should have thrown ServerException");
+        } catch (ServerException $exception) {
+            self::assertSame(500, $exception->getCode());
+            self::assertSame("Server error: `POST https://awesome-api.com/url` resulted in a `500 Internal Server Error` response:\nThis method is not implemented\n", $exception->getMessage());
         }
     }
 }

--- a/tests/Feature/AbstractRequestTest.php
+++ b/tests/Feature/AbstractRequestTest.php
@@ -710,14 +710,13 @@ class AbstractRequestTest extends BaseTestCase
     public function testRequestCanReturnStaticResponseWithoutAffectingDependencyStore(): void
     {
         $requestWithCustomTapper = new class extends ConcreteRequest {
-            protected bool $shouldWriteCache = false; // the requests are identical but we want the second to still try to call the network (and fail)
+            // $requestWithCustomTapper and $requestWithSystemGuzzle are identical, so make sure cache doesn't confuse this test outcome
+            protected bool $shouldWriteCache = false;
             protected function getGuzzleClient(): Client
             {
                 $tapper = new GuzzleTapper();
                 $tapper->addMatchBody('POST', '/awesome/', 'Static data as documented', 200);
-                $mockHandler = new MockHandler($tapper->getResponses());
-                $handlerStack = HandlerStack::create($mockHandler);
-                return new Client(['handler' => $handlerStack]);
+                return $tapper->makeMockedGuzzleClient();
             }
         };
         $this->mockGuzzleWithTapper()->addMatchBody('POST', '/awesome/', 'This method is not implemented', 500);


### PR DESCRIPTION
I'm introducing this change because we have dozens and dozens of APIs that use request classes, but right now we have **one** new set of requests that have to interoperate as if they're live, but still return mocked data.

Adding this capability to the request classes seemed like smart encapsulation, all the surrounding code can act as if the requests are really using the network. And re-using Tapper is firmly within our wheelhouse -- that seems like it leaves the door open for really feature rich mocks like using `addMatch` with a lambda that reads and reacts to the request body.