### PR TITLE
fix: issue-23, requests should be logged even if they're not matched

### DIFF
--- a/app/Testing/GuzzleTapper.php
+++ b/app/Testing/GuzzleTapper.php
@@ -105,8 +105,9 @@ class GuzzleTapper
 
     /**
      * Given a RequestInterface (from a unit test trying to make a Guzzle request)
-     * Find the first appropriate match (NOT best-match!) in $this->matches
      *  - Log that the request happened (so we can assert later what requests happened in what order)
+     *    - Even if the request is not matched, it will be logged so you can have confidence in your tests
+     *  - Find the first appropriate match (NOT best-match!) in $this->matches
      *  - Run and return the behavior described in the match
      * @returns Response a Guzzle response object, including status, headers, body
      * @returns Exception if the behavior *returns* an exception, Guzzle will throw it, e.g. a BadResponseException
@@ -114,15 +115,12 @@ class GuzzleTapper
      */
     public function response(RequestInterface $request, array $options = [])
     {
-        $requestMethod = $request->getMethod();
-        if (!array_key_exists($requestMethod, $this->matches)) {
-            return new \OutOfBoundsException("No responses match method {$requestMethod}");
-        }
+        $this->calls->push($request);
 
+        $requestMethod = $request->getMethod();
         $requestUrl = (string) $request->getUri();
-        foreach ($this->matches[$requestMethod] as $pattern => $response) {
+        foreach ($this->matches[$requestMethod] ?? [] as $pattern => $response) {
             if (preg_match($pattern, $requestUrl)) {
-                $this->calls->push($request);
                 if (is_callable($response)) {
                     return $response($request);
                 }

--- a/tests/Unit/GuzzleTapperTest.php
+++ b/tests/Unit/GuzzleTapperTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Str;
 use Carsdotcom\ApiRequest\Testing\MocksGuzzleInstance;
+use OutOfBoundsException;
 use Tests\BaseTestCase;
 
 class GuzzleTapperTest extends BaseTestCase
@@ -17,21 +18,30 @@ class GuzzleTapperTest extends BaseTestCase
 
     public function testUnmatchedMethod()
     {
-        $tapper = $this->mockGuzzleWithTapper();
-        $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage("match method GET");
+        $this->mockGuzzleWithTapper();
 
-        app()->make('guzzle')->get("http://hopeless.com");
+        try {
+            app()->make('guzzle')->get("http://hopeless.com");
+            self::fail("Should have thrown OutOfBoundsException");
+        } catch (OutOfBoundsException $exception) {
+            self::assertSame('No GET responses match URL http://hopeless.com', $exception->getMessage());
+            // Even misses should be logged as having been attempted
+            self::assertAllTapperRequestsLike([['GET', '#^http://hopeless.com$#']]);
+        }
     }
 
     public function testUnmatchedURL()
     {
-        $tapper = $this->mockGuzzleWithTapper();
-        $tapper->addMatchBody('GET', '/hopeful/', 'true');
-        $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage("match URL ");
+        $this->mockGuzzleWithTapper()->addMatchBody('GET', '/hopeful/', 'true');
 
-        app()->make('guzzle')->get("http://hopeless.com");
+        try {
+            app()->make('guzzle')->get("http://hopeless.com");
+            self::fail("Should have thrown OutOfBoundsException");
+        } catch (OutOfBoundsException $exception) {
+            self::assertSame('No GET responses match URL http://hopeless.com', $exception->getMessage());
+            // Even misses should be logged as having been attempted
+            self::assertAllTapperRequestsLike([['GET', '#^http://hopeless.com$#']]);
+        }
     }
 
     public function testCanReuseCalls()


### PR DESCRIPTION
Working on MR-5345, we're replacing *most* calls to Accounts Hexagon, but not all. If you're not careful (pobody's nerfect) and you un-mock Accounts Hexagon, your assertAllTapperRequestsLike will start to drift for things like entitlements and OEM data that we *can't* get from CustomerAPI yet