### PR TITLE
fix: Make exception params nullable and update test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.2']
+        php: ['8.2', '8.3', '8.4']
         laravel: [9.*, 10.*, 11.*, 12.*]
         include:
           - php: 8.1

--- a/app/Exceptions/NotFoundException.php
+++ b/app/Exceptions/NotFoundException.php
@@ -17,7 +17,7 @@ class NotFoundException extends HttpException
      * It is highly suggested that you customize the message with the name of the resource that isn't found.
      * @param string $message
      */
-    public function __construct(string $message = null, ?Throwable $previous = null)
+    public function __construct(?string $message = null, ?Throwable $previous = null)
     {
         parent::__construct(Response::HTTP_NOT_FOUND, $message ?: 'Not found', $previous);
     }

--- a/app/Exceptions/RemoteAuthentication.php
+++ b/app/Exceptions/RemoteAuthentication.php
@@ -15,7 +15,7 @@ class RemoteAuthentication extends HttpException
      * Optional message is a good way to elaborate what, if anything, you can do to troubleshoot this. (e.g., change value X in integration Y)
      * @param string $message
      */
-    public function __construct(string $message = null)
+    public function __construct(?string $message = null)
     {
         parent::__construct(
             Response::HTTP_UNAUTHORIZED,

--- a/app/Exceptions/UpstreamException.php
+++ b/app/Exceptions/UpstreamException.php
@@ -11,6 +11,7 @@ namespace Carsdotcom\ApiRequest\Exceptions;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
 
 class UpstreamException extends HttpException
 {
@@ -21,7 +22,7 @@ class UpstreamException extends HttpException
      * @param array $headers
      * @param int|null $code
      */
-    public function __construct(string $message, \Throwable $previous = null, array $headers = [], ?int $code = 0)
+    public function __construct(string $message, ?Throwable $previous = null, array $headers = [], ?int $code = 0)
     {
         parent::__construct(Response::HTTP_BAD_GATEWAY, $message, $previous, $headers, $code);
     }

--- a/app/Testing/MocksGuzzleInstance.php
+++ b/app/Testing/MocksGuzzleInstance.php
@@ -84,7 +84,7 @@ trait MocksGuzzleInstance
         self::assertSame($expectedRequestCount, $this->tapper->getCountAll());
     }
 
-    protected function assertTapperRequestLike(string $method, string $urlPattern, int $count = null): void
+    protected function assertTapperRequestLike(string $method, string $urlPattern, ?int $count = null): void
     {
         if (is_int($count)) {
             self::assertSame(


### PR DESCRIPTION
Allow nullable types for several exception constructors and update a test helper signature.

Changes:
- NotFoundException: make $message nullable (?string) and allow nullable $previous.
- RemoteAuthentication: make $message nullable (?string).
- UpstreamException: import Throwable and make $previous nullable (?Throwable).
- MocksGuzzleInstance: allow $count to be nullable (?int) in assertTapperRequestLike.

These changes prevent strict type errors when null values are passed and align signatures across exceptions and tests.