### PR TITLE
chore: add PHP 8.5 and Laravel 13 to test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
-        laravel: [9.*, 10.*, 11.*, 12.*]
+        php: ['8.2', '8.3', '8.4', '8.5']
+        laravel: [9.*, 10.*, 11.*, 12.*, 13.*]
+        exclude:
+          - php: '8.2'
+            laravel: '13.*'
         include:
           - php: 8.1
             laravel: 9.*

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "ext-simplexml": "*",
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",
-        "laravel/framework": "^9.19 || ^10.0 || ^11.0  || ^12.0"
+        "laravel/framework": "^9.19 || ^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
         "nunomaduro/collision": "^6.1|7.*|8.*",
-        "orchestra/testbench": "7.*|8.*|9.*|10.*",
+        "orchestra/testbench": "7.*|8.*|9.*|10.*|11.*",
         "phpstan/phpstan": "^1.8|^2.1",
         "phpunit/phpunit": "~8.0|~9.0|^10.5|^11.5.3",
         "squizlabs/php_codesniffer": "^3.7",


### PR DESCRIPTION
## Summary
- Adds PHP 8.5 and Laravel 13 to the CI test matrix
- Excludes the PHP 8.2 + Laravel 13 combination since Laravel 13 requires PHP 8.3+

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)