### PR TITLE
feat: add getCacheTags() method to replace direct property access

### DIFF
--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -46,6 +46,11 @@ abstract class AbstractRequest
     /** @var array Tags to be used when inserting to cache */
     protected array $cacheTags = [];
 
+    public function getCacheTags(): array
+    {
+        return $this->cacheTags;
+    }
+
     /** @var string Request method, for use in toGuzzle */
     protected string $method = 'POST';
 
@@ -317,7 +322,7 @@ abstract class AbstractRequest
 
     public function purgeCache(): self
     {
-        Cache::tags($this->cacheTags)->forget($this->cacheKey());
+        Cache::tags($this->getCacheTags())->forget($this->cacheKey());
         return $this;
     }
 
@@ -338,7 +343,7 @@ abstract class AbstractRequest
         // so we flatten the body to strings then rehydrate the Response class manually
         // Note, when the format of the cached value changes, you have to update CACHE_KEY_SEED
         // So that previous cache entries with incompatible cached data are not read by responseFromCache
-        Cache::tags($this->cacheTags)->put(
+        Cache::tags($this->getCacheTags())->put(
             $this->cacheKey(),
             [
                 'logs' => $this->sentLogs,
@@ -363,7 +368,7 @@ abstract class AbstractRequest
 
         // Note, when the format of $fromCache changes, you have to update CACHE_KEY_SEED
         // So that previous cache entries with incompatible cached data are not read by responseFromCache
-        $fromCache = Cache::tags($this->cacheTags)->get($this->cacheKey());
+        $fromCache = Cache::tags($this->getCacheTags())->get($this->cacheKey());
         if ($fromCache) {
             $this->sentLogs = array_map(
                 fn ($filename) => Str::contains($filename, '/')
@@ -396,7 +401,7 @@ abstract class AbstractRequest
 
     public function canBeFulfilledByCache(): bool
     {
-        return Cache::tags($this->cacheTags)->has($this->cacheKey());
+        return Cache::tags($this->getCacheTags())->has($this->cacheKey());
     }
 
     public function isFromCache(): bool

--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -21,7 +21,7 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
     {
         $cachedResponse = parent::responseFromCache();
         if ($cachedResponse && $this->needsRefresh()) {
-            Cache::tags($this->cacheTags)->put(
+            Cache::tags($this->getCacheTags())->put(
                 $this->refreshCacheKey(),
                 'Wait between refreshes',
                 $this->waitBetweenRefreshes(),
@@ -44,7 +44,7 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
     protected function writeResponseToCache(): void
     {
         if ($this->shouldWriteResponseToCache()) {
-            Cache::tags($this->cacheTags)->put($this->refreshCacheKey(), 'refresh after', $this->refreshAfter());
+            Cache::tags($this->getCacheTags())->put($this->refreshCacheKey(), 'refresh after', $this->refreshAfter());
         }
         parent::writeResponseToCache();
     }
@@ -63,12 +63,12 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
 
     public function needsRefresh(): bool
     {
-        return !Cache::tags($this->cacheTags)->has($this->refreshCacheKey());
+        return !Cache::tags($this->getCacheTags())->has($this->refreshCacheKey());
     }
 
     public function refreshOnNextRequest(): self
     {
-        Cache::tags($this->cacheTags)->forget($this->refreshCacheKey());
+        Cache::tags($this->getCacheTags())->forget($this->refreshCacheKey());
         return $this;
     }
 

--- a/app/Testing/RequestClassAssertions.php
+++ b/app/Testing/RequestClassAssertions.php
@@ -21,8 +21,7 @@ trait RequestClassAssertions
         array $headers = [],
         array $logs = [],
     ): void {
-        $tags = getProperty($request, 'cacheTags');
-        Cache::tags($tags)->put($request->cacheKey(), [
+        Cache::tags($request->getCacheTags())->put($request->cacheKey(), [
             'logs' => $logs,
             'response' => [$status, $headers, $body],
         ]);


### PR DESCRIPTION
## Summary
- Adds `getCacheTags(): array` to `AbstractRequest`, returning `$this->cacheTags` by default
- All internal cache interactions in `AbstractRequest` and `AbstractUseStaleRequest` now go through `getCacheTags()` instead of the property directly
- `RequestClassAssertions` updated to call `$request->getCacheTags()` instead of the `getProperty` reflection helper

## Motivation
It's a recurring pattern (e.g. carsdotcom/modern-retailing-shared#3591) for implementers to set `cacheTags` in the constructor, where the tags are really just derived from other properties — not independent state that needs to be serialized. Providing `getCacheTags()` as the extension point lets future implementers simply override the method instead, keeping tags derived rather than stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)