### PR TITLE
feat: add onBackgroundRefreshFailed hook to AbstractUseStaleRequest

### DIFF
--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -33,8 +33,8 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
                         ->setReadCache(false)
                         ->setWriteCache(true)
                         ->sync();
-                } catch (\Throwable) {
-                    // Nobody cares, this is literally what use-stale is good at
+                } catch (\Throwable $e) {
+                    $reRequest->onBackgroundRefreshFailed($e);
                 }
             });
         }
@@ -77,6 +77,8 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
         $this->refreshOnNextRequest();
         return parent::purgeCache();
     }
+
+    protected function onBackgroundRefreshFailed(\Throwable $e): void {}
 
     // Children of this class are *required* to thoughtfully implement their own PHP 8.1+ style serialization,
     // to work with `dispatch` in `responseFromCache`


### PR DESCRIPTION
## Release Notes

Adds an extensibility hook to `AbstractUseStaleRequest` so consumers can observe background refresh failures without the library forcing specific behaviour.

## Technical Notes

The background refresh closure previously swallowed all `\Throwable` silently:

```php
} catch (\Throwable) {
    // Nobody cares, this is literally what use-stale is good at
}
```

The new no-op hook:

```php
} catch (\Throwable $e) {
    $reRequest->onBackgroundRefreshFailed($e);
}

protected function onBackgroundRefreshFailed(\Throwable $e): void {}
```

Consumers override `onBackgroundRefreshFailed()` in their subclass or via a trait to add logging or metrics. The library itself stays behaviour-neutral.

## Corresponding Tickets

MR-7177

## Checklist

- [x] PR is ready to review
- [x] Enough tests are added to feel fully confident
- [x] Product / Stakeholder signoff