### PR TITLE
feat: permit laravel-json-schema ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "carsdotcom/laravel-json-schema": "^v2.3",
+        "carsdotcom/laravel-json-schema": "^v2.3 || ^3.0",
         "ext-simplexml": "*",
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",


### PR DESCRIPTION
## Summary
- Expands the `carsdotcom/laravel-json-schema` version constraint from `^v2.3` to `^v2.3 || ^3.0` so projects on schema v3 can install this package without conflicts.

## Test plan
- [x] CI test matrix passes across all PHP/Laravel version combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)