### PR TITLE
refactor: early-return writeResponseToCache on cache hit

### DIFF
--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -43,9 +43,10 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
 
     protected function writeResponseToCache(): void
     {
-        if ($this->shouldWriteResponseToCache()) {
-            Cache::tags($this->getCacheTags())->put($this->refreshCacheKey(), 'refresh after', $this->refreshAfter());
+        if (!$this->shouldWriteResponseToCache()) {
+            return;
         }
+        Cache::tags($this->getCacheTags())->put($this->refreshCacheKey(), 'refresh after', $this->refreshAfter());
         parent::writeResponseToCache();
     }
 

--- a/tests/Feature/AbstractUseStaleRequestTest.php
+++ b/tests/Feature/AbstractUseStaleRequestTest.php
@@ -121,6 +121,63 @@ class AbstractUseStaleRequestTest extends BaseTestCase
         self::assertTrue($request->needsRefresh(), 'But we want to refresh opportunistically');
     }
 
+    public function testCacheHitDoesNotWriteRefreshMarker(): void
+    {
+        $request = new ConcreteUseStaleRequest('thing');
+
+        self::mockRequestCachedResponse($request, 'cached body');
+        Cache::tags($request->getCacheTags())->put(
+            $request->refreshCacheKey(),
+            'sentinel',
+            Carbon::now()->addMinutes(15),
+        );
+
+        self::assertSame('cached body', $request->sync());
+
+        self::assertSame(
+            'sentinel',
+            Cache::tags($request->getCacheTags())->get($request->refreshCacheKey()),
+            'Refresh marker should be untouched on a cache hit — writeResponseToCache must early-return.',
+        );
+    }
+
+    public function testFreshFetchWritesRefreshMarker(): void
+    {
+        $this->mockGuzzleWithTapper()->addMatchBody('GET', '/test/', 'fresh');
+        $request = new ConcreteUseStaleRequest('thing');
+
+        self::assertNull(
+            Cache::tags($request->getCacheTags())->get($request->refreshCacheKey()),
+            'Marker should not exist before first fetch.',
+        );
+
+        self::assertSame('fresh', $request->sync());
+
+        self::assertSame(
+            'refresh after',
+            Cache::tags($request->getCacheTags())->get($request->refreshCacheKey()),
+            'A successful live fetch must write the refresh marker.',
+        );
+    }
+
+    public function testWriteCacheDisabledSkipsRefreshMarker(): void
+    {
+        $this->mockGuzzleWithTapper()->addMatchBody('GET', '/test/', 'fresh');
+        $request = new ConcreteUseStaleRequest('thing');
+        $request->setWriteCache(false);
+
+        self::assertSame('fresh', $request->sync());
+
+        self::assertNull(
+            Cache::tags($request->getCacheTags())->get($request->refreshCacheKey()),
+            'setWriteCache(false) must prevent the refresh marker write.',
+        );
+        self::assertFalse(
+            $request->canBeFulfilledByCache(),
+            'setWriteCache(false) must also prevent the response from being cached.',
+        );
+    }
+
     public function testCacheBehaviorUnderHeavyLoad(): void
     {
         Queue::fake();


### PR DESCRIPTION
## Summary

Restructure `AbstractUseStaleRequest::writeResponseToCache()` to early-return when `shouldWriteResponseToCache()` is false, instead of wrapping only the refresh-marker write and then falling through to `parent::writeResponseToCache()`.

## Why

The previous shape was correct in net effect — the parent already short-circuits on cache hit via its own guard — but it had two drawbacks:

1. On every cache-hit invocation it still walked into `parent::writeResponseToCache()`, doing duplicate guard work that produced no side effects.
2. Subclasses overriding `writeResponseToCache()` got an unclear contract: calling `parent::` looked like it might do something, but actually never did on a cache hit.

The new shape makes the no-op explicit. If a subclass calls `parent::writeResponseToCache()` and adds side effects after, the parent's behavior is now unambiguous: it either fully wrote (marker + response) or it didn't run at all.

This is motivated by debugging an AIS-side bug ([MR-7089](https://carscommerce.atlassian.net/browse/MR-7089)) where a subclass of `AbstractUseStaleRequest` added `Cache::tags(...)->flush()` after `parent::writeResponseToCache()`. The flush fired on every cache hit because nothing in the chain signalled "no write happened." Cleaner framework semantics make that class of mistake easier to spot.

## What changed

- `app/AbstractUseStaleRequest.php` — `writeResponseToCache()` now returns at the top when the guard is false.
- `tests/Feature/AbstractUseStaleRequestTest.php` — three new tests covering the three branches:
  - `testCacheHitDoesNotWriteRefreshMarker` — seeds a sentinel marker, calls `sync()`, asserts the sentinel survives.
  - `testFreshFetchWritesRefreshMarker` — asserts the marker is written with value `'refresh after'` after a live fetch.
  - `testWriteCacheDisabledSkipsRefreshMarker` — asserts `setWriteCache(false)` blocks both the marker write and the response write.

## Behavior change

None at the framework boundary — all existing tests should still pass, including `testCacheBehaviorUnderHeavyLoad` which exercises the full lifecycle. The parent method simply isn't invoked on a cache hit anymore (it would have no-op'd anyway).

## Test plan

- [x] `vendor/bin/phpunit tests/Feature/AbstractUseStaleRequestTest.php` passes locally
- [x] Full suite passes in CI

[MR-7089]: https://carscommerce.atlassian.net/browse/MR-7089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ