### PR TITLE
fix: skip use-stale background job when cache already refreshed (MR-7760)

### DIFF
--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -17,6 +17,9 @@ use Illuminate\Support\Facades\Cache;
 
 abstract class AbstractUseStaleRequest extends AbstractRequest
 {
+    public const CACHE_IS_NOT_STALE = 'refresh after';
+    public const CACHE_STALE_REFRESH_IS_QUEUED = 'Wait between refreshes';
+
     protected function responseFromCache(): ?Response
     {
         $cachedResponse = parent::responseFromCache();
@@ -64,9 +67,6 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
     {
         return $this->cacheKey() . ':REFRESH';
     }
-
-    public const CACHE_IS_NOT_STALE = 'refresh after';
-    public const CACHE_STALE_REFRESH_IS_QUEUED = 'Wait between refreshes';
 
     public function needsRefresh(): bool
     {

--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -23,7 +23,7 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
         if ($cachedResponse && $this->needsRefresh()) {
             Cache::tags($this->getCacheTags())->put(
                 $this->refreshCacheKey(),
-                'Wait between refreshes',
+                self::CACHE_STALE_REFRESH_IS_QUEUED,
                 $this->waitBetweenRefreshes(),
             );
             $reRequest = clone $this;
@@ -49,7 +49,7 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
         if (!$this->shouldWriteResponseToCache()) {
             return;
         }
-        Cache::tags($this->getCacheTags())->put($this->refreshCacheKey(), 'refresh after', $this->refreshAfter());
+        Cache::tags($this->getCacheTags())->put($this->refreshCacheKey(), self::CACHE_IS_NOT_STALE, $this->refreshAfter());
         parent::writeResponseToCache();
     }
 
@@ -65,6 +65,9 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
         return $this->cacheKey() . ':REFRESH';
     }
 
+    public const CACHE_IS_NOT_STALE = 'refresh after';
+    public const CACHE_STALE_REFRESH_IS_QUEUED = 'Wait between refreshes';
+
     public function needsRefresh(): bool
     {
         return !Cache::tags($this->getCacheTags())->has($this->refreshCacheKey());
@@ -72,7 +75,7 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
 
     public function cacheIsCurrentlyFresh(): bool
     {
-        return Cache::tags($this->getCacheTags())->get($this->refreshCacheKey()) === 'refresh after';
+        return Cache::tags($this->getCacheTags())->get($this->refreshCacheKey()) === self::CACHE_IS_NOT_STALE;
     }
 
     public function refreshOnNextRequest(): self

--- a/app/AbstractUseStaleRequest.php
+++ b/app/AbstractUseStaleRequest.php
@@ -29,6 +29,9 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
             $reRequest = clone $this;
             dispatch(function () use ($reRequest) {
                 try {
+                    if ($reRequest->cacheIsCurrentlyFresh()) {
+                        return;
+                    }
                     $reRequest
                         ->setReadCache(false)
                         ->setWriteCache(true)
@@ -65,6 +68,11 @@ abstract class AbstractUseStaleRequest extends AbstractRequest
     public function needsRefresh(): bool
     {
         return !Cache::tags($this->getCacheTags())->has($this->refreshCacheKey());
+    }
+
+    public function cacheIsCurrentlyFresh(): bool
+    {
+        return Cache::tags($this->getCacheTags())->get($this->refreshCacheKey()) === 'refresh after';
     }
 
     public function refreshOnNextRequest(): self

--- a/tests/Feature/AbstractUseStaleRequestTest.php
+++ b/tests/Feature/AbstractUseStaleRequestTest.php
@@ -178,6 +178,43 @@ class AbstractUseStaleRequestTest extends BaseTestCase
         );
     }
 
+    public function testDeferredJobSkipsWhenCacheAlreadyRefreshed(): void
+    {
+        Queue::fake();
+        $this->mockGuzzleWithTapper()->addMatchBody('GET', '/test/', 'constant');
+        $request = new ConcreteUseStaleRequest('thing');
+
+        self::mockRequestCachedResponse($request, 'Antique');
+
+        // First stale request queues J1
+        Carbon::setTestNow('2026-01-01 00:00:00');
+        self::assertSame('Antique', $request->sync());
+        $j1 = null;
+        Queue::assertPushed(function (CallQueuedClosure $job) use (&$j1) {
+            $j1 = $job->closure->getClosure();
+            return true;
+        });
+
+        // Advance past waitBetweenRefreshes so a second stale request can queue J2
+        Queue::fake();
+        Carbon::setTestNow('2026-01-01 00:06:00');
+        self::assertSame('Antique', $request->sync());
+        $j2 = null;
+        Queue::assertPushed(function (CallQueuedClosure $job) use (&$j2) {
+            $j2 = $job->closure->getClosure();
+            return true;
+        });
+
+        // J1 runs first — makes a network call and marks the cache fresh
+        $j1();
+        $this->assertTapperRequestLike('GET', '#test/thing#', 1);
+        self::assertTrue($request->cacheIsCurrentlyFresh());
+
+        // J2 runs after J1 has already refreshed — should terminate without a network call
+        $j2();
+        $this->expectTotalRequestCount(1);
+    }
+
     public function testCacheBehaviorUnderHeavyLoad(): void
     {
         Queue::fake();

--- a/tests/Feature/AbstractUseStaleRequestTest.php
+++ b/tests/Feature/AbstractUseStaleRequestTest.php
@@ -154,7 +154,7 @@ class AbstractUseStaleRequestTest extends BaseTestCase
         self::assertSame('fresh', $request->sync());
 
         self::assertSame(
-            'refresh after',
+            ConcreteUseStaleRequest::CACHE_IS_NOT_STALE,
             Cache::tags($request->getCacheTags())->get($request->refreshCacheKey()),
             'A successful live fetch must write the refresh marker.',
         );


### PR DESCRIPTION
## Summary

- Adds `cacheIsCurrentlyFresh()` to `AbstractUseStaleRequest` — returns `true` when the refresh key holds the `'refresh after'` marker written by a successful `writeResponseToCache()` call
- The dispatched background closure checks this before making a network request; if another job has already refreshed the cache, it returns immediately
- Covers the storm scenario: a backlogged queue drains and many duplicate refresh jobs hit upstream simultaneously — now only the first one through actually makes the network call

## Why `needsRefresh()` alone doesn't work here

`needsRefresh()` returns `false` for two distinct states:

| State | refreshCacheKey value | `needsRefresh()` |
|---|---|---|
| Job queued, hasn't run yet | `'Wait between refreshes'` | `false` |
| Prior job succeeded | `'refresh after'` | `false` |

Using `needsRefresh()` in the closure would incorrectly bail out jobs that run quickly (within the 5-minute snooze window). Checking the actual stored value correctly distinguishes the two states.

## Test plan

- [x] `testDeferredJobSkipsWhenCacheAlreadyRefreshed` — new test: two jobs queued across the `waitBetweenRefreshes` boundary; J1 runs and refreshes; J2 asserts zero additional network calls
- [x] All 74 existing tests pass unchanged
- [x] CI green

Closes MR-7760

🤖 Generated with [Claude Code](https://claude.com/claude-code)