### PR TITLE
fix: toGuzzle uses getHeaders() for send-time computed auth headers

### DIFF
--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -247,7 +247,7 @@ abstract class AbstractRequest
         $this->setAcceptHeaders();
         $this->setOnStats();
 
-        return new Request($this->method, $this->getURL(), $this->headers, $this->encodeBody());
+        return new Request($this->method, $this->getURL(), $this->getHeaders(), $this->encodeBody());
     }
 
     /**
@@ -260,7 +260,25 @@ abstract class AbstractRequest
     }
 
     /**
-     * Simple readonly getter to read the headers so far.
+     * Getter for the headers to be sent with the request. Called by toGuzzle() immediately before send,
+     * so it is the preferred place to attach headers that must be computed freshly (e.g., pulled from a
+     * secrets store, or a compiled JWT) rather than set once in __construct().
+     *
+     * This matters for AbstractUseStaleRequest: the background refresh job serializes/unserializes a clone
+     * of the request, so anything only set in __construct() (or otherwise stored as plain state) reflects
+     * whatever it was at the time of the *original* request, not a fresh value at refresh time. Overriding
+     * getHeaders() (the same pattern used by getCacheTags()) instead of relying on the $headers property
+     * ensures the value is recomputed every time the request is actually sent, both before and after
+     * serialization.
+     *
+     * @example
+     *   public function getHeaders(): array
+     *   {
+     *       return array_merge(parent::getHeaders(), [
+     *           'Authorization' => 'Bearer ' . $this->fetchToken(),
+     *       ]);
+     *   }
+     *
      * @return array
      */
     public function getHeaders(): array

--- a/app/AbstractRequest.php
+++ b/app/AbstractRequest.php
@@ -274,9 +274,10 @@ abstract class AbstractRequest
      * @example
      *   public function getHeaders(): array
      *   {
-     *       return array_merge(parent::getHeaders(), [
+     *       return [
+     *           ...parent::getHeaders(),
      *           'Authorization' => 'Bearer ' . $this->fetchToken(),
-     *       ]);
+     *       ];
      *   }
      *
      * @return array


### PR DESCRIPTION
## Summary
- `AbstractRequest::toGuzzle()` now builds the Guzzle `Request` from `$this->getHeaders()` instead of the raw `$this->headers` property.
- Documents `getHeaders()` as the preferred override point for headers that need to be computed at send time (e.g. pulled from secrets, or a compiled JWT), mirroring the existing `getCacheTags()` override pattern.

## Why
Auth headers set only in `__construct()` go stale for `AbstractUseStaleRequest` background refreshes, since the refresh job clones and serializes the request before re-sending it off the queue. Overriding `getHeaders()` instead recomputes the header fresh every time the request is actually sent, both before and after serialization.

## Test plan
- [x] Existing suite passes: `tests/Feature/AbstractRequestTest.php`, `tests/Feature/AbstractUseStaleRequestTest.php`, `tests/Feature/LogFileTest.php` (58 tests, 271 assertions)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)